### PR TITLE
5.18: new patchset, clone of 5.17

### DIFF
--- a/5.18/00_all_0001-unifdef-drop-unused-errno.h-include.patch
+++ b/5.18/00_all_0001-unifdef-drop-unused-errno.h-include.patch
@@ -1,0 +1,32 @@
+From c4d1a109c5c0b1bd27d2b5448a1306a2f6005339 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Tue, 6 Dec 2011 17:22:42 -0500
+Subject: [PATCH] unifdef: drop unused errno.h include
+
+This is the only header on my system that ends up requiring kernel
+headers, so if the kernel headers aren't available, we end up being
+unable to install kernel headers :).
+
+Since this file doesn't actually use anything from errno.h, drop
+the include so it at least makes us a bit more robust on glibc.
+
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+---
+ scripts/unifdef.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/unifdef.c b/scripts/unifdef.c
+index 7493c0ee51cc..c5dfae538b08 100644
+--- a/scripts/unifdef.c
++++ b/scripts/unifdef.c
+@@ -48,7 +48,6 @@
+ 
+ #include <ctype.h>
+ #include <err.h>
+-#include <errno.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+-- 
+2.16.1
+

--- a/5.18/00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
+++ b/5.18/00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch
@@ -1,0 +1,33 @@
+From 57875de37c5375ea95e1e949ec7c741d0038d3a1 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Sat, 15 Nov 2014 03:37:38 -0500
+Subject: [PATCH] x86: do not build relocs tool when installing headers
+
+This isn't needed to install headers, so don't bother building it.
+Otherwise we run into a chicken/egg issue where we need the kernel
+headers in order to install the kernel headers.  It's also a waste
+of time.
+
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+---
+ arch/x86/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 60135cbd905c..9b15b2daa77f 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -215,8 +215,10 @@
+ endif
+ 
+ 
++ifneq ($(filter-out headers_install,$(MAKECMDGOALS)),)
+ archscripts: scripts_basic
+ 	$(Q)$(MAKE) $(build)=arch/x86/tools relocs
++endif
+ 
+ ###
+ # Syscall table generation
+-- 
+2.16.1
+


### PR DESCRIPTION
0003 is fixed upstream.

* 5.18/00_all_0001-unifdef-drop-unused-errno.h-include.patch
* 5.18/00_all_0002-x86-do-not-build-relocs-tool-when-installing-headers.patch